### PR TITLE
Add example phonons configs

### DIFF
--- a/configs/phonons-atoms-only.yml
+++ b/configs/phonons-atoms-only.yml
@@ -1,0 +1,21 @@
+struct: NaCl.xyz
+struct-name: NaCl
+supercell: 2x2x2
+displacement: 0.01
+fmax: 0.001
+thermal: True
+temp-start: 0
+temp-end: 1000
+temp-step: 10
+band: True
+dos: True
+minimize: True
+minimize-kwargs:
+  filter_func: null
+
+arch: mace_mp
+write-full: True
+plot-to-file: True
+calc-kwargs:
+  model: small
+device: cpu

--- a/configs/phonons-cell-lengths-only.yml
+++ b/configs/phonons-cell-lengths-only.yml
@@ -1,0 +1,22 @@
+struct: NaCl.xyz
+struct-name: NaCl
+supercell: 2x2x2
+displacement: 0.01
+fmax: 0.001
+thermal: True
+temp-start: 0
+temp-end: 1000
+temp-step: 10
+band: True
+dos: True
+minimize: True
+minimize-kwargs:
+  filter-kwargs:
+    hydrostatic_strain: True
+
+arch: mace_mp
+write-full: True
+plot-to-file: True
+calc-kwargs:
+  model: small
+device: cpu

--- a/configs/phonons-pressure.yml
+++ b/configs/phonons-pressure.yml
@@ -1,5 +1,5 @@
-struct: myu.xyz
-struct-name: my
+struct: NaCl.xyz
+struct-name: NaCl
 supercell: 2x2x2
 displacement: 0.01
 fmax: 0.001
@@ -9,15 +9,14 @@ temp-end: 1000
 temp-step: 10
 band: True
 dos: True
-minimize: True  
+minimize: True
 minimize-kwargs:
-    filter-kwargs: 
-       hydrostatic_strain: True
+  filter-kwargs:
+    scalar_pressure: 0.5
 
 arch: mace_mp
 write-full: True
 plot-to-file: True
 calc-kwargs:
-   model: large
-device: cuda
- 
+  model: small
+device: cpu


### PR DESCRIPTION
Adds configs with different minimization kwargs:

1. Atoms-only
2. Atoms and cell lengths only
3. Atoms, cell lengths and angles, with a specified pressure

One thing we need to note somewhere is that setting something to `None` via the config requires `null`, but in the command line you must put `None`, e.g. ` --minimize-kwargs "{'filter_func': None}"`, since it's parsed differently, which is not particularly nice.