### PR TITLE
Adds dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:22.04
+# Disable optional install (saves image size).
+RUN echo 'APT::Install-Suggests "0";' >> /etc/apt/apt.conf.d/00-docker
+RUN echo 'APT::Install-Recommends "0";' >> /etc/apt/apt.conf.d/00-docker
+# Install minimal dependencies.
+#   python3-dev (i.e. headers), gcc, g++, and ninja-build for phonopy.
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y python3-dev python3 git ninja-build python3-pip gcc g++
+# Clean up package list.
+RUN rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install git+https://github.com/stfc/janus-core.git
+
+RUN useradd -ms /bin/bash pika
+USER pika


### PR DESCRIPTION
Adds a bare-bones working dockerfile as a starting point.

Things to resolve

- [ ] Where shall it go (file currently in root and Image registry).
- [ ] How shall we integrate into CI (some discussion #16) for running.
- [ ] Do we want multiple python versions (say using micromamba) to test?
- [ ] Do we want multiple OS images to test?  

This is the output I got on a simple test.

```shell
pika@a88ea36e0241:~$ cat test.py 
from ase.build import bulk
from ase.io import read

from janus_core.calculations.md import NVT
from janus_core.helpers.stats import Stats

NaCl = bulk('NaCl', 'rocksalt', a=5.63, cubic=True)
NaCl = NaCl * (2,2,2)

cooling = NVT(
    struct=NaCl.copy(),
    arch='mace_mp',
    device='cpu',
    model_path='small',
    calc_kwargs={'default_dtype': 'float64'},
    temp_start=300.0,
    temp_end=200.0,
    temp_step=20,
    temp_time=5,
    stats_every=2,
)

cooling.run()

data = Stats('Cl32Na32-nvt-T300.0-T200.0-stats.dat')
print(data)
pika@a88ea36e0241:~$ python3 test.py 
Downloading MACE model from 'https://github.com/ACEsuit/mace-mp/releases/download/mace_mp_0/2023-12-10-mace-128-L0_energy_epoch-249.model'
Cached MACE model to /home/pika/.cache/mace/20231210mace128L0_energy_epoch249model
Using Materials Project MACE for MACECalculator with /home/pika/.cache/mace/20231210mace128L0_energy_epoch249model
Using float64 for MACECalculator, which is slower but more accurate. Recommended for geometry optimization.
/usr/local/lib/python3.10/dist-packages/ase/io/extxyz.py:311: UserWarning: Skipping unhashable information real_time
  warnings.warn('Skipping unhashable information '
contains 17 timeseries, each with 16 elements
index label units
0 # Step 
1 Real_Time s
2 Time fs
3 Epot/N eV
4 EKin/N eV
5 T K
6 ETot/N eV
7 Density g/cm^3
8 Volume A^3
9 P GPa
10 Pxx GPa
11 Pyy GPa
12 Pzz GPa
13 Pyz GPa
14 Pxz GPa
15 Pxy GPa
16 Target_T K
pika@a88ea36e0241:~$ ls
Cl32Na32-nvt-T300.0-T200.0-final.extxyz  Cl32Na32-nvt-T300.0-T200.0-traj.extxyz  test.py
Cl32Na32-nvt-T300.0-T200.0-stats.dat     janus-tutorials
```